### PR TITLE
Feature Issue #18: remove state tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # adsrex
 
-Collection of functional tests for ADS Api and Bumblebee.
+Collection of functional tests for the ADS API and ADS Bumblebee.
 
 A minimal configuration is necessary, create a `local_config.py`
 and set the values as described in the `config.py`

--- a/v1_0/api/base.py
+++ b/v1_0/api/base.py
@@ -2,7 +2,8 @@
 Base class for all tests
 """
 import unittest
-from ..user_roles import AnonymousUser, AuthenticatedUser, BumblebeeAnonymousUser
+from ..user_roles import AnonymousUser, AuthenticatedUser,\
+    BumblebeeAnonymousUser
 
 
 class TestBase(unittest.TestCase):

--- a/v1_0/api/citation_helper.py
+++ b/v1_0/api/citation_helper.py
@@ -1,5 +1,6 @@
+# encoding: utf-8
 """
-Integration tests for the Citation Helper service
+Functional tests for the Citation Helper service
 """
 
 from base import TestBase
@@ -14,24 +15,28 @@ class TestCitationHelper(TestBase):
         Generic setup. Updated to include a test bibcode.
         """
         super(TestCitationHelper, self).setUp()
-        self.test_bibcodes = ['a', 'b']
+        self.test_bibcodes = ['1980ApJS...44..169S', '1980ApJS...44..193S']
 
     def test_anonymous_user_existing_bibcode(self):
         """
-        Test an unauthenticated user has no access to the citation helper for a GET request for all the bibcodes sent
+        Test an unauthenticated user has no access to the citation helper for a
+        GET request for all the bibcodes sent
         """
         # Request all metrics for two existing bibcodes
-        r = self.anonymous_user.post('/citation_helper', json={'bibcodes': self.test_bibcodes})
+        r = self.anonymous_user.post(
+            '/citation_helper', json={'bibcodes': self.test_bibcodes}
+        )
         self.assertEqual(
             r.status_code,
             401,
-            msg='We expect a 401 unauthorized error, but get: {}, {}'.format(r.status_code, r.json())
+            msg='We expect a 401 unauthorized error, but get: {}, {}'
+                .format(r.status_code, r.json())
         )
         
     def helper_authenticated_user_get_request(self, user=None):
         """
-        Test that an authenaticated user has access to the GET end point for a list of bibcodes and that the response
-        contains the expected content.
+        Test that an authenaticated user has access to the GET end point for a
+        list of bibcodes and that the response contains the expected content.
         :param user: the user to run the test on
         :type user: object
         """
@@ -39,14 +44,16 @@ class TestCitationHelper(TestBase):
         self.assertEqual(
             r.status_code,
             200,
-            msg='We should get a 200 response for a request including two bibcodes, but get: {}, {}'
+            msg='We should get a 200 response for a request including two '
+                'bibcodes, but instead we get: {}, {}'
                 .format(r.status_code, r.json())
         )
 
         self.assertIsInstance(
             r.json(),
             list,
-            msg='Response content should be of type list, but are type: {}, {}'.format(type(r.json()), r.json())
+            msg='Response content should be of type list, but are type: {}, {}'
+                .format(type(r.json()), r.json())
         )
         # and all list items should be dictionaries
         expected_attr = ['title', 'bibcode', 'score', 'author']
@@ -54,20 +61,22 @@ class TestCitationHelper(TestBase):
             self.assertIsInstance(
                 item,
                 dict,
-                msg='All list items should be dictionaries, but not this: "{}" is type {}'.format(item, type(item))
+                msg='All list items should be dictionaries, '
+                    'but not this: "{}" is type {}'.format(item, type(item))
             )
 
             actual_attr = item.keys()
             self.assertListEqual(
                 actual_attr,
                 expected_attr,
-                msg='There are mising attributes, expected {} != actual {}'.format(expected_attr, actual_attr)
+                msg='There are mising attributes, expected {} != actual {}'
+                    .format(expected_attr, actual_attr)
             )
 
     def test_authenticated_user_get_request(self):
         """
-        Test that all types of authenticated users can access the citation helper GET end point, and get the expected
-        content in the response
+        Test that all types of authenticated users can access the citation
+        helper GET end point, and get the expected content in the response
         """
         self.helper_authenticated_user_get_request(user=self.authenticated_user)
         self.helper_authenticated_user_get_request(user=self.bumblebee_user)

--- a/v1_0/api/core.py
+++ b/v1_0/api/core.py
@@ -3,9 +3,6 @@
 Core tests of the ADS web services
 """
 
-import time
-import unittest
-
 from base import TestBase
 
 
@@ -15,8 +12,8 @@ class TestCore(TestBase):
 
     XXX / TODO: response from /resources
 
-    the response is organized from the perspective of the ADS developer/ API maintainer but API users probably expect to
-    see something like:
+    the response is organized from the perspective of the ADS developer/API
+    maintainer but API users probably expect to see something like:
     {
     '/v1': {
        'endpoints': [
@@ -32,8 +29,8 @@ class TestCore(TestBase):
      }
     }
 
-    If we run two versions of the API alongside, I don't see how the current structure can communicate two different
-    'bases'
+    If we run two versions of the API alongside, I don't see how the current
+    structure can communicate two different 'bases'
     """
 
     def test_status(self):
@@ -69,7 +66,8 @@ class TestCore(TestBase):
 
     def test_resources_accounts(self):
         """
-        Test that the expected resources are returned from the api accounts endpoints
+        Test that the expected resources are returned from the api accounts
+        endpoints
         """
 
         r = self.anonymous_user.get(self.anonymous_user.api_base + '/resources')
@@ -103,7 +101,8 @@ class TestCore(TestBase):
 
     def test_resources_feedback(self):
         """
-        Test that the expected resources are returned from the api accounts endpoints
+        Test that the expected resources are returned from the api accounts
+        endpoints
         """
 
         r = self.anonymous_user.get(self.anonymous_user.api_base + '/resources')
@@ -207,11 +206,17 @@ class TestCore(TestBase):
         # repeating the bootstrap request should give you the
         # same access token
         for x in xrange(5):
-            r = self.anonymous_user.get('/accounts/bootstrap', headers={'Cookie': b_cookie})
+            r = self.anonymous_user.get(
+                '/accounts/bootstrap',
+                headers={'Cookie': b_cookie}
+            )
             self.assertEqual(r.json()['access_token'], b['access_token'])
 
         for x in xrange(5):
-            r = self.authenticated_user.get('/accounts/bootstrap', headers={'Cookie': a_cookie})
+            r = self.authenticated_user.get(
+                '/accounts/bootstrap',
+                headers={'Cookie': a_cookie}
+            )
             self.assertEqual(r.json()['access_token'], a['access_token'])
 
     def test_crossx_headers(self):

--- a/v1_0/api/graphics.py
+++ b/v1_0/api/graphics.py
@@ -1,5 +1,6 @@
+# encoding: utf-8
 """
-Integration tests for the Graphics service
+Functional tests for the Graphics service
 """
 
 from base import TestBase
@@ -14,7 +15,7 @@ class TestGraphics(TestBase):
         Generic setup. Updated to include a test bibcode.
         """
         super(TestGraphics, self).setUp()
-        self.test_bibcode = '2014ApJS..214...17J'
+        self.test_bibcode = '1995ApJ...447L..37W'
 
     def test_unauthenticated_get_graphics(self):
         """
@@ -31,7 +32,8 @@ class TestGraphics(TestBase):
         self.assertEqual(
             401,
             r.status_code,
-            msg='This is a non-existing bibcode, it should return a 401 not {}'.format(r.status_code)
+            msg='This is a non-existing bibcode, it should return a 401 not {}'
+                .format(r.status_code)
         )
 
     def helper_authenticated_user_get(self, user=None):
@@ -55,23 +57,27 @@ class TestGraphics(TestBase):
         self.assertEqual(
             data['bibcode'],
             self.test_bibcode,
-            msg='The data structure sent back has a "bibcode" entry, which should contain the request bibcode'
+            msg='The data structure sent back has a "bibcode" entry, '
+                'which should contain the request bibcode'
         )
 
         self.assertFalse(
             data['eprint'],
-            msg='eprint attribrudge should be False, but is: {}'.format(data['eprint'])
+            msg='eprint attribrudge should be False, but is: {}'
+                .format(data['eprint'])
         )
 
         self.assertIsInstance(
             data['figures'],
             list,
-            msg='The attribute "figures" should be a list: type is {}'.format(type(data['figures']))
+            msg='The attribute "figures" should be a list: type is {}'
+                .format(type(data['figures']))
         )
         #
         self.assertTrue(
             len(data['figures']) > 0,
-            msg='The list of figures should not be empty: length = {}'.format(len(data['figures']))
+            msg='The list of figures should not be empty: length = {}'
+                .format(len(data['figures']))
         )
 
         expected_attr = [u'images', u'figure_caption', u'figure_label', u'figure_id']
@@ -79,20 +85,23 @@ class TestGraphics(TestBase):
         self.assertEqual(
             actual_attr.sort(),
             expected_attr.sort(),
-            msg='A figure in the list of figures should have expected attributes. Expected {} got {}'
+            msg='A figure in the list of figures should have expected '
+                'attributes. Expected {} got {}'
                 .format(expected_attr, data['figures'][0].keys())
         )
 
         self.assertIsInstance(
             data['figures'][0]['images'],
             list,
-            msg='The attribute "images" refers to a list but has type: {}'.format(type(data['figures'][0]['images']))
+            msg='The attribute "images" refers to a list but has type: {}'
+                .format(type(data['figures'][0]['images']))
         )
 
         #
         self.assertTrue(
             len(data['figures'][0]['images']) > 0,
-            msg='The list of images should not be empty, but has length: {}'.format(len(data['figures'][0]['images']))
+            msg='The list of images should not be empty, but has length: {}'
+                .format(len(data['figures'][0]['images']))
         )
 
         im_attr = [u'image_id', u'format', u'thumbnail', u'highres']
@@ -110,16 +119,17 @@ class TestGraphics(TestBase):
 
     def test_authenticated_user_get(self):
         """
-        Tests the graphics GET end point for all types of authenticated users. They should all receive the same
-        response, otherwise something is wrong.
+        Tests the graphics GET end point for all types of authenticated users.
+        They should all receive the same response, otherwise something is wrong.
         """
         self.helper_authenticated_user_get(user=self.authenticated_user)
         self.helper_authenticated_user_get(user=self.bumblebee_user)
 
     def helper_authenticated_user_non_existent_bibcode(self, user=None):
         """
-        Check that the graphics GET end point works as expected if there is no corresponding bibcode. This is a helper
-        function that allows it to be run on a give user.
+        Check that the graphics GET end point works as expected if there is no
+        corresponding bibcode. This is a helper function that allows it to be
+        run on a give user.
         :param user: the user to run the test on
         :type user: object
         """
@@ -129,12 +139,17 @@ class TestGraphics(TestBase):
         self.assertIn(
             'Error',
             r.json(),
-            msg='The data structure sent back should have an "Error" attribute, but does not: {}'.format(r.json())
+            msg='The data structure sent back should have an "Error" attribute, '
+                'but does not: {}'.format(r.json())
         )
 
     def test_authenticated_user_non_existent_bibcode(self):
         """
         A non-existing bibcode should still return a 200
         """
-        self.helper_authenticated_user_non_existent_bibcode(user=self.authenticated_user)
-        self.helper_authenticated_user_non_existent_bibcode(user=self.bumblebee_user)
+        self.helper_authenticated_user_non_existent_bibcode(
+            user=self.authenticated_user
+        )
+        self.helper_authenticated_user_non_existent_bibcode(
+            user=self.bumblebee_user
+        )

--- a/v1_0/api/metrics.py
+++ b/v1_0/api/metrics.py
@@ -1,5 +1,6 @@
+# encoding: utf-8
 """
-Integration tests for the Graphics service
+Functional tests for the Graphics service
 """
 
 from base import TestBase
@@ -14,23 +15,28 @@ class TestMetrics(TestBase):
         Generic setup. Updated to include a test bibcode.
         """
         super(TestMetrics, self).setUp()
-        self.test_bibcodes = ['1994GPC.....9...69H', '1993CoPhC..74..239H']
+        self.test_bibcodes = ['1993CoPhC..74..239H', '1994GPC.....9...69H']
 
     def test_anonymous_user(self):
         """
-        Test unauthenticated user cannot request all metrics for two existing bibcodes
+        Test unauthenticated user cannot request all metrics for two existing
+        bibcodes
         """
-        r = self.anonymous_user.post('/metrics', json={'bibcodes': self.test_bibcodes})
+        r = self.anonymous_user.post(
+            '/metrics',
+            json={'bibcodes': self.test_bibcodes}
+        )
         self.assertEqual(
             r.status_code,
             401,
-            msg='We should get a 401 status but got: {}, {}'.format(r.status_code, r.json())
+            msg='We should get a 401 status but got: {}, {}'
+                .format(r.status_code, r.json())
         )
 
     def helper_authenticated_user_posts_metrics(self, user):
         """
-        Test that authenticated users can post to the metrics end point, and receive the expected response based on
-        the bibcodes they sent.
+        Test that authenticated users can post to the metrics end point, and
+        receive the expected response based on the bibcodes they sent.
         :param user: the user to run the test on
         :type user: object
         """
@@ -46,7 +52,8 @@ class TestMetrics(TestBase):
         self.assertIsInstance(
             r.json(),
             dict,
-            msg='The results should be in a dictionary but it is: {}'.format(type(r.json()))
+            msg='The results should be in a dictionary but it is: {}'
+                .format(type(r.json()))
         )
 
         expected_attr = [u'basic stats', u'citation stats refereed',
@@ -57,7 +64,8 @@ class TestMetrics(TestBase):
         self.assertEqual(
             expected_attr.sort(),
             actual_attr.sort(),
-            msg='Did not get expected attribtues. Expected {} is not same as actual {}'
+            msg='Did not get expected attribtues. Expected "{}" is not same '
+                'as actual "{}"'
                 .format(expected_attr, actual_attr)
         )
 
@@ -66,23 +74,41 @@ class TestMetrics(TestBase):
         self.assertListEqual(
             expected_hists,
             actual_hists,
-            msg='Should have retrieved all histograms, but did not. Expected {} != actual {}'
+            msg='Should have retrieved all histograms, but did not. '
+                'Expected "{}" != actual "{}"'
                 .format(expected_hists, actual_hists)
         )
 
         # All histograms should have the expected constituents
         histdict = {
-            'downloads': [u'refereed downloads', u'all downloads normalized',
-                          u'all downloads', u'refereed downloads normalized'],
-            'reads': [u'refereed reads', u'all reads normalized', 
-                      u'all reads', u'refereed reads normalized'],
-            'publications': [u'refereed publications', u'all publications',
-                             u'refereed publications normalized',
-                             u'all publications normalized'],
-            'citations': [u'refereed to nonrefereed', u'nonrefereed to nonrefereed',
-                          u'nonrefereed to nonrefereed normalized', u'nonrefereed to refereed',
-                          u'refereed to refereed normalized', u'refereed to nonrefereed normalized',
-                          u'refereed to refereed', u'nonrefereed to refereed normalized']
+            'downloads': [
+                u'refereed downloads',
+                u'all downloads normalized',
+                u'all downloads',
+                u'refereed downloads normalized'
+            ],
+            'reads': [
+                u'refereed reads',
+                u'all reads normalized',
+                u'all reads',
+                u'refereed reads normalized'
+            ],
+            'publications': [
+                u'refereed publications',
+                u'all publications',
+                u'refereed publications normalized',
+                u'all publications normalized'
+            ],
+            'citations': [
+                u'refereed to nonrefereed',
+                u'nonrefereed to nonrefereed',
+                u'nonrefereed to nonrefereed normalized',
+                u'nonrefereed to refereed',
+                u'refereed to refereed normalized',
+                u'refereed to nonrefereed normalized',
+                u'refereed to refereed',
+                u'nonrefereed to refereed normalized'
+            ]
         }
 
         for hist in expected_hists:
@@ -91,7 +117,8 @@ class TestMetrics(TestBase):
             self.assertItemsEqual(
                 expected_hist,
                 actual_hist,
-                msg='All histograms should have expected consitutents. They do not match. Expected {} != Actual {}'
+                msg='All histograms should have expected consitutents. '
+                    'They do not match. Expected "{}" != Actual "{}"'
                     .format(expected_hist, actual_hist)
             )
         # All histogram constituents should be dictionaries
@@ -102,36 +129,88 @@ class TestMetrics(TestBase):
                 self.assertIsInstance(
                     histogram,
                     dict,
-                    msg='All histogram consituents should be dictionaries, but is type: {}'.format(type(histogram))
+                    msg='All histogram consituents should be dictionaries, '
+                        'but is type: {}'.format(type(histogram))
                 )
 
         expected_stats = {
-            'indicators': [u'g', u'read10', u'm', u'i10', u'riq', u'h', u'i100', u'tori'],
-            'indicators refereed': [u'g', u'read10', u'm', u'i10', u'riq', u'h', u'i100', u'tori'],
-            'basic stats': [u'median number of downloads', u'average number of reads',
-                            u'normalized paper count', u'recent number of reads', u'number of papers',
-                            u'recent number of downloads', u'total number of reads',
-                            u'median number of reads', u'total number of downloads',
-                            u'average number of downloads'],
-            'basic stats refereed': [u'median number of downloads', u'average number of reads',
-                                     u'normalized paper count', u'recent number of reads', u'number of papers',
-                                     u'recent number of downloads', u'total number of reads',
-                                     u'median number of reads', u'total number of downloads',
-                                     u'average number of downloads'],
-            'citation stats': [u'normalized number of citations', u'average number of refereed citations',
-                               u'median number of citations', u'median number of refereed citations',
-                               u'number of citing papers', u'average number of citations',
-                               u'total number of refereed citations',
-                               u'normalized number of refereed citations',
-                               u'number of self-citations', u'total number of citations'],
-            'citation stats refereed': [u'normalized number of citations',
-                                        u'average number of refereed citations',
-                                        u'median number of citations', u'median number of refereed citations',
-                                        u'number of citing papers', u'average number of citations',
-                                        u'total number of refereed citations',
-                                        u'normalized number of refereed citations',
-                                        u'number of self-citations', u'total number of citations'],
-            'time series': [u'g', u'h', u'tori', u'i10', u'read10', u'i100']        
+            'indicators': [
+                u'g',
+                u'read10',
+                u'm',
+                u'i10',
+                u'riq',
+                u'h',
+                u'i100',
+                u'tori'
+            ],
+            'indicators refereed': [
+                u'g',
+                u'read10',
+                u'm',
+                u'i10',
+                u'riq',
+                u'h',
+                u'i100',
+                u'tori'
+            ],
+            'basic stats': [
+                u'median number of downloads',
+                u'average number of reads',
+                u'normalized paper count',
+                u'recent number of reads',
+                u'number of papers',
+                u'recent number of downloads',
+                u'total number of reads',
+                u'median number of reads',
+                u'total number of downloads',
+                u'average number of downloads'
+            ],
+            'basic stats refereed': [
+                u'median number of downloads',
+                u'average number of reads',
+                u'normalized paper count',
+                u'recent number of reads', u'number '
+                u'of papers',
+                u'recent number of downloads',
+                u'total number of reads',
+                u'median number of reads',
+                u'total number of downloads',
+                u'average number of downloads'
+            ],
+            'citation stats': [
+                u'normalized number of citations',
+                u'average number of refereed citations',
+                u'median number of citations',
+                u'median number of refereed '
+                u'citations',
+                u'number of citing papers',
+                u'average number of citations',
+                u'total number of refereed citations',
+                u'normalized number of refereed citations',
+                u'number of self-citations',
+                u'total number of citations'
+            ],
+            'citation stats refereed': [
+                u'normalized number of citations',
+                u'average number of refereed citations',
+                u'median number of citations',
+                u'median number of refereed citations',
+                u'number of citing papers',
+                u'average number of citations',
+                u'total number of refereed citations',
+                u'normalized number of refereed citations',
+                u'number of self-citations',
+                u'total number of citations'
+            ],
+            'time series': [
+                u'g',
+                u'h',
+                u'tori',
+                u'i10',
+                u'read10',
+                u'i100'
+            ]
         }
         for entry in expected_stats:
             expected_stat = expected_stats[entry]
@@ -139,7 +218,8 @@ class TestMetrics(TestBase):
             self.assertItemsEqual(
                 expected_stat,
                 actual_stat,
-                msg='Did not get all indicators. Expected {} != Actual {} for entry "{}"'
+                msg='Did not get all indicators. '
+                    'Expected "{}" != Actual "{}" for entry "{}"'
                     .format(expected_stat, actual_stat, entry)
             )
 
@@ -148,7 +228,8 @@ class TestMetrics(TestBase):
         self.assertListEqual(
             expected_bibcodes,
             actual_bibcodes,
-            msg='There should be no skipped bibcodes. Expected {} is not actual {}'
+            msg='There should be no skipped bibcodes. '
+                'Expected "{} is not actual "{}"'
                 .format(expected_bibcodes, actual_bibcodes)
         )
 
@@ -163,29 +244,36 @@ class TestMetrics(TestBase):
         """
         Tests that posting an empty list responds with a 403.
         """
-        r = self.authenticated_user.post('/metrics', json={'bibcodes': []},)
+        r = self.authenticated_user.post('/metrics', json={'bibcodes': []})
         self.assertEqual(
             r.status_code,
             403,
-            msg='An empty list should return 403, but returns: {}'.format(r.status_code)
+            msg='An empty list should return 403, but returns: {}'
+                .format(r.status_code)
         )
 
     def test_get_for_single_bibcode(self):
         """
-        Tests that you can obtain metrics for a single bibcode via the GET end point
+        Tests that you can obtain metrics for a single bibcode via the GET end
+        point
         """
-        r = self.authenticated_user.get('/metrics/{}'.format(self.test_bibcodes[0]))
+        r = self.authenticated_user.get(
+            '/metrics/{}'.format(self.test_bibcodes[0])
+        )
         self.assertEqual(
             r.status_code,
             200,
-            msg='We should get a 200, but get: {}, {}'.format(r.status_code, r.json())
+            msg='We should get a 200, but get: {}, {}'
+                .format(r.status_code, r.json())
         )
 
     def test_post_single_bibcode(self):
         """
         Tests that you can post a single bibcode to the metrics POST end point
         """
-        r = self.authenticated_user.post('/metrics', json={'bibcodes': self.test_bibcodes[:1]})
+        r = self.authenticated_user.post(
+            '/metrics', json={'bibcodes': self.test_bibcodes[:1]}
+        )
         self.assertEqual(
             r.status_code,
             200,

--- a/v1_0/api/myads.py
+++ b/v1_0/api/myads.py
@@ -1,6 +1,9 @@
+# encoding: utf-8
 """
-Integration tests for the myADS services
+Functional tests for the myADS services
 """
+
+import unittest
 
 from base import TestBase
 
@@ -24,60 +27,78 @@ class TestMyADS(TestBase):
             self.assertEqual(
                 401,
                 r.status_code,
-                msg='We expect a 401 from an unauthorized user, but get: {}, {}'.format(r.status_code, r.json())
+                msg='We expect a 401 from an unauthorized user, but get: {}, {}'
+                    .format(r.status_code, r.json())
             )
-            assert r.status_code == 401
+            self.assertEqual(
+                r.status_code,
+                401,
+                msg='We expect a 401 status code, but we get: {}, {}'
+                    .format(r.status_code, r.text)
+            )
 
+    @unittest.skip('Needs a test user to exist in the database')
     def test_get_request_random_user_query2svg(self):
         """
         A user does not have to be associated to the query to execute the query
         """
-        r = self.bumblebee_user.get('/vault/query2svg/c8ed1163e7643cea5e81aaefb4bb2d91')
+        r = self.bumblebee_user.get(
+            '/vault/query2svg/c8ed1163e7643cea5e81aaefb4bb2d91'
+        )
         self.assertEqual(
             200,
             r.status_code,
-            msg='We expect a 200 for an unauthorized user, but get: {}, {}'.format(r.status_code, r.text)
+            msg='We expect a 200 for an unauthorized user, but get: {}, {}'
+                .format(r.status_code, r.text)
         )
 
     def test_get_configuration_authenticated_user(self):
         """
-        Test an authenticated user can access the configuration end point, that holds the bumblebee config
+        Test an authenticated user can access the configuration end point, that
+        holds the bumblebee config
         """
         r = self.authenticated_user.get('/vault/configuration')
         self.assertEqual(
             200,
             r.status_code,
-            msg='We expect a 200 for an authorized user, but get: {}, {}'.format(r.status_code, r.text)
+            msg='We expect a 200 for an authorized user, but get: {}, {}'
+                .format(r.status_code, r.text)
         )
         self.assertIsInstance(
             r.json(),
             dict,
-            msg='Expect the response to be type dict, but is type: {}, {}'.format(type(r.json()), r.json())
+            msg='Expect the response to be type dict, but is type: {}, {}'
+                .format(type(r.json()), r.json())
         )
         self.assertIn(
             'link_servers',
             r.json(),
-            msg='Expect to find "link_servers" in the response, but do not: {}'.format(r.json())
+            msg='Expect to find "link_servers" in the response, but do not: {}'
+                .format(r.json())
         )
 
     def test_get_configuration_link_servers_authenticated_user(self):
         """
-        Test that an authenticated user can access a keyword via the configuration end point
+        Test that an authenticated user can access a keyword via the
+        configuration end point
         """
         r = self.authenticated_user.get('/vault/configuration/link_servers')
         self.assertEqual(
             200,
             r.status_code,
-            msg='We expect a 200 for an authorized user, but get: {}, {}'.format(r.status_code, r.text)
+            msg='We expect a 200 for an authorized user, but get: {}, {}'
+                .format(r.status_code, r.text)
         )
         self.assertIsInstance(
             r.json(),
             list,
-            msg='Expect the response to be type list, but is type: {}, {}'.format(type(r.json()), r.json())
+            msg='Expect the response to be type list, but is type: {}, {}'
+                .format(type(r.json()), r.json())
         )
         self.assertTrue(
             all([isinstance(i, dict) for i in r.json()]),
-            msg='All items of the response should be of type dict, but are not: {}'.format(r.json())
+            msg='All items of the response should be of type dict, '
+                'but they are not: {}'.format(r.json())
         )
         expected_keys = ['name', 'link', 'gif']
         for dictionary in r.json():
@@ -85,59 +106,74 @@ class TestMyADS(TestBase):
             self.assertEqual(
                 expected_keys.sort(),
                 actual_keys.sort(),
-                msg='Expected keys {} are not equal to actual keys {}'.format(expected_keys, actual_keys)
+                msg='Expected keys {} are not equal to actual keys {}'
+                    .format(expected_keys, actual_keys)
             )
 
+    @unittest.skip('Needs a test user to exist in the database')
     def test_user_data_work_flow_authenticated_user(self):
         """
-        Test that an authenticated user can save key-values via the user-data end point, and then retrieve them
-        afterwards using the user-data end point
+        Test that an authenticated user can save key-values via the user-data
+        endpoint, and then retrieve them afterwards using the user-data end
+        point
         """
-        r1 = self.authenticated_user.post('/vault/user-data', json={'link_server': 'foo'})
+        r1 = self.authenticated_user.post(
+            '/vault/user-data',
+            json={'link_server': 'foo'}
+        )
+
         self.assertEqual(
             200,
             r1.status_code,
-            msg='We expect a 200 for an authorized user, but get: {}, {}'.format(r1.status_code, r1.json())
+            msg='We expect a 200 for an authorized user, but get: {}, {}'
+                .format(r1.status_code, r1.json())
         )
         self.assertEqual(
             'foo',
             r1.json().get('link_server', 'notfoo'),
-            msg='Did not find expected key "foo", contains keys: {}'.format(r1.json())
+            msg='Did not find expected key "foo", contains keys: {}'
+                .format(r1.json())
         )
 
         r2 = self.authenticated_user.get('/vault/user-data')
         self.assertEqual(
             200,
             r2.status_code,
-            msg='We expect a 200 for an authorized user, but get: {}, {}'.format(r2.status_code, r2.json())
+            msg='We expect a 200 for an authorized user, but get: {}, {}'
+                .format(r2.status_code, r2.json())
         )
         self.assertIsInstance(
             r2.json(),
             dict,
-            msg='Expect the response to be type dict, but is type: {}, {}'.format(type(r2.json()), r2.json())
+            msg='Expect the response to be type dict, but is type: {}, {}'
+                .format(type(r2.json()), r2.json())
         )
         self.assertEqual(
             'foo',
             r2.json().get('link_server', 'notfoo'),
-            msg='Did not find expected key "foo", contains keys: {}'.format(r2.json())
+            msg='Did not find expected key "foo", contains keys: {}'
+                .format(r2.json())
         )
 
+    @unittest.skip('Needs a test user to exist in the database')
     def test_post_query_authenticated_user(self):
         """
-        Test that an authenticated user can save queries via the query end point, and then execute them in a vanilla
-        style
+        Test that an authenticated user can save queries via the query endpoint,
+        and then execute them in a vanilla style
         """
         # POST the query to be saved
         r1 = self.authenticated_user.post('/vault/query', json={'q': '*:*'})
         self.assertEqual(
             200,
             r1.status_code,
-            msg='We expect a 200 for an authorized user, but get: {}, {}'.format(r1.status_code, r1.text)
+            msg='We expect a 200 for an authorized user, but get: {}, {}'
+                .format(r1.status_code, r1.text)
         )
         self.assertIsInstance(
             r1.json(),
             dict,
-            msg='Expect the response to be type dict, but is type: {}, {}'.format(type(r1.json()), r1.json())
+            msg='Expect the response to be type dict, but is type: {}, {}'
+                .format(type(r1.json()), r1.json())
         )
 
         query_id = r1.json()['qid']
@@ -147,74 +183,93 @@ class TestMyADS(TestBase):
         self.assertEqual(
             200,
             r2.status_code,
-            msg='We expect a 200 for an authorized user, but get: {}, {}'.format(r2.status_code, r2.json())
+            msg='We expect a 200 for an authorized user, but get: {}, {}'
+                .format(r2.status_code, r2.json())
         )
         self.assertIn(
             'numfound',
             r2.json(),
-            msg='Expected to find "numfound" in response, but did not: {}'.format(r2.json())
+            msg='Expected to find "numfound" in response, but did not: {}'
+                .format(r2.json())
         )
 
         # GET/execute the query that was saved in a vanilla style
-        r3 = self.authenticated_user.get('/vault/execute_query/{}'.format(query_id))
+        r3 = self.authenticated_user.get('/vault/execute_query/{}'
+                                         .format(query_id))
         self.assertEqual(
             200,
             r3.status_code,
-            msg='We expect a 200 for an authorized user, but get: {}, {}'.format(r3.status_code, r3.json())
+            msg='We expect a 200 for an authorized user, but get: {}, {}'
+                .format(r3.status_code, r3.json())
         )
         self.assertEqual(
             r3.json()['responseHeader']['params']['q'],
             '*:*',
-            msg='Expected return query to be "*:*" but is {}'.format(r3.json()['responseHeader']['params']['q'])
+            msg='Expected return query to be "*:*" but is {}'
+                .format(r3.json()['responseHeader']['params']['q'])
         )
         self.assertEqual(
             r3.json()['responseHeader']['params']['wt'],
             'json',
-            msg='Expected return field to be "recid" but is {}'.format(r3.json()['responseHeader']['params']['wt'])
+            msg='Expected return field to be "recid" but is {}'
+                .format(r3.json()['responseHeader']['params']['wt'])
         )
         self.assertTrue(
             r3.json()['response'],
-            msg='Expected "response" keyword to be True, but is: {}'.format(r3.json()['response'])
+            msg='Expected "response" keyword to be True, but is: {}'
+                .format(r3.json()['response'])
         )
 
         # GET/execute the query that was saved with extra parameters
-        r4 = self.authenticated_user.get('/vault/execute_query/{}?fl=recid'.format(query_id))
+        r4 = self.authenticated_user.get('/vault/execute_query/{}?fl=recid'
+                                         .format(query_id))
         self.assertEqual(
             200,
             r4.status_code,
-            msg='We expect a 200 for an authorized user, but get: {}, {}'.format(r4.status_code, r4.json())
+            msg='We expect a 200 for an authorized user, but get: {}, {}'
+                .format(r4.status_code, r4.json())
         )
         self.assertEqual(
             r4.json()['responseHeader']['params']['q'],
             '*:*',
-            msg='Expected return query to be "*:*" but is {}'.format(r4.json()['responseHeader']['params']['q'])
+            msg='Expected return query to be "*:*" but is {}'
+                .format(r4.json()['responseHeader']['params']['q'])
         )
         self.assertEqual(
             r4.json()['responseHeader']['params']['fl'],
             'recid',
-            msg='Expected return field to be "recid" but is {}'.format(r4.json()['responseHeader']['params']['fl'])
+            msg='Expected return field to be "recid" but is {}'
+                .format(r4.json()['responseHeader']['params']['fl'])
         )
         self.assertTrue(
             r4.json()['response'],
-            msg='Expected "response" keyword to be True, but is: {}'.format(r4.json()['response'])
+            msg='Expected "response" keyword to be True, but is: {}'
+                .format(r4.json()['response'])
         )
 
         # GET/create svg of query that was saved
-        r5 = self.authenticated_user.get('/vault/query2svg/{}'.format(query_id))
+        r5 = self.authenticated_user.get('/vault/query2svg/{}'
+                                         .format(query_id))
         self.assertEqual(
             200,
             r5.status_code,
-            msg='We expect a 200 for an authorized user, but get: {}, {}'.format(r5.status_code, r5.text)
+            msg='We expect a 200 for an authorized user, but get: {}, {}'
+                .format(r5.status_code, r5.text)
         )
-        self.assertIn('svg', r5.text, msg='Expected "svg" in the response, but it is not: {}'.format(r5.text))
+        self.assertIn('svg', r5.text, msg='Expected "svg" in the response, '
+                                          'but it is not: {}'.format(r5.text))
 
-        # Looks like the API overrides the Content-Type after the end point specifies it to "image/svg+xml",
-        # as it always returns as "text/html; charset=utf-8"
-        # If I am right/wrong, this can be modified/uncommented once the issue has been resolved:
+        # Looks like the API overrides the Content-Type after the end point
+        # specifies it to "image/svg+xml", as it always returns as
+        # "text/html; charset=utf-8"
+
+        # If I am right/wrong, this can be modified/uncommented once the issue
+        # has been resolved:
         # https://github.com/adsabs/adsws/issues/83
         #
         #  self.assertEqual(
         #     r5.headers.get('Content-Type'),
         #     'image/svg+xml',
-        #     msg='Expected "image/svg+xml" to be in the response header, it is not: {}'.format(r5.headers.keys())
+        #     msg='Expected "image/svg+xml" to be in the response header, '
+        #         'but it is not: {}'.format(r5.headers.keys())
         # )

--- a/v1_0/api/orcid.py
+++ b/v1_0/api/orcid.py
@@ -1,5 +1,6 @@
+# encoding: utf-8
 """
-Integration tests for the orcid-service
+Functional tests for the orcid-service
 """
 
 import unittest
@@ -13,7 +14,8 @@ class TestOrcidService(TestBase):
     """
     def test_get_exchange_oauth_unauthorised_user(self):
         """
-        Test that an unauthorised user cannot access the orcid/exchangeOAuthCode end point
+        Test that an unauthorised user cannot access the orcid/exchangeOAuthCode
+        endpoint
         """
         for end_point in ['/orcid/exchangeOAuthCode']:
             r = self.anonymous_user.get(end_point)
@@ -21,12 +23,14 @@ class TestOrcidService(TestBase):
             self.assertEqual(
                 401,
                 r.status_code,
-                msg='We expect 401 response for an unauthorised user, but get: {}, {}'.format(r.status_code, r.json())
+                msg='We expect 401 response for an unauthorised user, '
+                    'but get: {}, {}'.format(r.status_code, r.text)
             )
 
     def helper_extract_works(self, orcid_data):
         """
-        Orcid data is awful: collect the relevant entries related to a given client ID
+        Orcid data is awful: collect the relevant entries related to a given
+        client ID
 
         :param orcid_data: ORCID data to bootstrap
         :type orcid_data: dict
@@ -54,97 +58,115 @@ class TestOrcidService(TestBase):
         3. Add a selection of work to the ORCID profile
         4. Overwrite the documents we just added
 
-        Getting the 'exchange token' involves logging into orcid and getting the code from the url redirect; but it
-        seems that ORCID allows us to get the code from the endpoint; but we have to know which url to contact and we
-        have to send username + password; this is obviously brittle and can break if they change something on their
-        side
+        Getting the 'exchange token' involves logging into orcid and getting the
+        code from the url redirect; but it seems that ORCID allows us to get the
+        code from the endpoint; but we have to know which url to contact and we
+        have to send username + password; this is obviously brittle and can
+        break if they change something on their side
         """
         redirect_uri = 'http://hourly.adslabs.org/#/user/orcid'
         if 'sandbox' not in self.authenticated_user.get_config('ORCID_OAUTH_ENDPOINT'):
             redirect_uri = 'https://ui.adsabs.harvard.edu/#/user/orcid'
 
         data = {
-            "errors": [],
-            "userName": {
-                "errors": [],
-                "value": self.authenticated_user.get_config('ORCID_USER'),
-                "required": True,
-                "getRequiredMessage": None
+            'errors': [],
+            'userName': {
+                'errors': [],
+                'value': self.authenticated_user.get_config('ORCID_USER'),
+                'required': True,
+                'getRequiredMessage': None
             },
-            "password": {
-                "errors": [],
-                "value": "Orcid123",
-                "required": True,
-                "getRequiredMessage": None
+            'password': {
+                'errors': [],
+                'value': 'Orcid123',
+                'required': True,
+                'getRequiredMessage': None
             },
-            "clientId": {
-                "errors": [],
-                "value": self.authenticated_user.get_config('ORCID_CLIENT_ID'),
-                "required": True,
-                "getRequiredMessage": None
+            'clientId': {
+                'errors': [],
+                'value': self.authenticated_user.get_config('ORCID_CLIENT_ID'),
+                'required': True,
+                'getRequiredMessage': None
             },
-            "redirectUri": {
-                "errors": [],
-                "value": redirect_uri,
-                "required": True,
-                "getRequiredMessage": None
+            'redirectUri': {
+                'errors': [],
+                'value': redirect_uri,
+                'required': True,
+                'getRequiredMessage': None
             },
-            "scope": {
-                "errors": [],
-                "value": "/orcid-profile/read-limited /orcid-works/create /orcid-works/update",
-                "required": True,
-                "getRequiredMessage": None
+            'scope': {
+                'errors': [],
+                'value': '/orcid-profile/read-limited /orcid-works/create /orcid-works/update',
+                'required': True,
+                'getRequiredMessage': None
             },
-            "responseType": {
-                "errors": [],
-                "value": "code",
-                "required": True,
-                "getRequiredMessage": None
+            'responseType': {
+                'errors': [],
+                'value': 'code',
+                'required': True,
+                'getRequiredMessage': None
             },
-            "approved": True,
-            "persistentTokenEnabled": False
+            'approved': True,
+            'persistentTokenEnabled': False
         }
 
-        r = requests.post(self.authenticated_user.get_config('ORCID_OAUTH_ENDPOINT'), json=data)
+        r = requests.post(
+            self.authenticated_user.get_config('ORCID_OAUTH_ENDPOINT'),
+            json=data
+        )
+
         try:
             redirect = r.json()['redirectUri']['value']
         except Exception as error:
-            self.fail('Something is wrong with the setup of the test: {}, {}'.format(error, r.text))
+            self.fail('Something is wrong with the setup of the test: {}, {}'
+                      .format(error, r.text))
         exchange_code = redirect.split('code=')[1].split('#')[0]
 
         # now we can test our own api
-        r = self.bumblebee_user.get('/orcid/exchangeOAuthCode', params={'code': exchange_code})
+        r = self.bumblebee_user.get(
+            '/orcid/exchangeOAuthCode',
+            params={'code': exchange_code}
+        )
+
         self.assertEqual(
             200,
             r.status_code,
-            msg='Expected a 200 response, but get: {}, {}'.format(r.status_code, r.json())
+            msg='Expected a 200 response, but get: {}, {}'
+                .format(r.status_code, r.json())
         )
         self.assertIn(
             'access_token',
             r.json(),
-            msg='Expected "access_token" in response, but it is not: {}'.format(r.json())
+            msg='Expected "access_token" in response, but it is not: {}'
+                .format(r.json())
         )
         self.assertIn(
             'orcid',
             r.json(),
-            msg='Expected "orcid" in response, but it is not: {}'.format(r.json())
+            msg='Expected "orcid" in response, but it is not: {}'
+                .format(r.json())
         )
 
         # these are the important keys that our own API needs
         access_token = r.json()['access_token']
         orcid = r.json()['orcid']
 
-        r = self.bumblebee_user.get('/orcid/{}/orcid-profile'.format(orcid),
-                                    headers={'Orcid-Authorization': 'Bearer {}'.format(access_token)})
+        r = self.bumblebee_user.get(
+            '/orcid/{}/orcid-profile'.format(orcid),
+            headers={'Orcid-Authorization': 'Bearer {}'.format(access_token)}
+        )
+
         self.assertEqual(
             200,
             r.status_code,
-            msg='Expected a 200 response, but get: {}, {}'.format(r.status_code, r.json())
+            msg='Expected a 200 response, but get: {}, {}'
+                .format(r.status_code, r.json())
         )
         self.assertIn(
             'orcid-profile',
             r.json(),
-            msg='Expected "orcid-profile" in the response, but it is not: {}, {}'.format(r.status_code, r.json())
+            msg='Expected "orcid-profile" in the response, '
+                'but it is not: {}, {}'.format(r.status_code, r.json())
         )
 
         new_data = {'message-version': '1.2',
@@ -153,129 +175,129 @@ class TestOrcidService(TestBase):
                              'orcid-works': {
                                 'orcid-work': [
                                    {
-                                     "language-code": None,
-                                     "source": {
-                                      "source-orcid": None,
-                                      "source-name": {
-                                       "value": "NASA ADS"
+                                     'language-code': None,
+                                     'source': {
+                                      'source-orcid': None,
+                                      'source-name': {
+                                       'value': 'NASA ADS'
                                       },
-                                      "source-date": {
-                                       "value": 1437165488504
+                                      'source-date': {
+                                       'value': 1437165488504
                                       },
-                                      "source-client-id": {
-                                       "path": self.authenticated_user.get_config('ORCID_CLIENT_ID'),
-                                       "host": "sandbox.orcid.org",
-                                       "uri": "http://sandbox.orcid.org/client/APP-P5ANJTQRRTMA6GXZ",
-                                       "value": None
+                                      'source-client-id': {
+                                       'path': self.authenticated_user.get_config('ORCID_CLIENT_ID'),
+                                       'host': 'sandbox.orcid.org',
+                                       'uri': 'http://sandbox.orcid.org/client/APP-P5ANJTQRRTMA6GXZ',
+                                       'value': None
                                       }
                                      },
-                                     "work-title": {
-                                      "translated-title": None,
-                                      "subtitle": None,
-                                      "title": {
-                                       "value": "Monte Carlo studies of medium-size telescope designs for the "
-                                                "Cherenkov Telescope Array"
+                                     'work-title': {
+                                      'translated-title': None,
+                                      'subtitle': None,
+                                      'title': {
+                                       'value': 'Monte Carlo studies of medium-size telescope designs for the '
+                                                'Cherenkov Telescope Array'
                                       }
                                      },
-                                     "created-date": {
-                                      "value": 1437165488504
+                                     'created-date': {
+                                      'value': 1437165488504
                                      },
-                                     "work-citation": None,
-                                     "work-type": "JOURNAL_ARTICLE",
-                                     "publication-date": {
-                                      "month": {
-                                       "value": "01"
+                                     'work-citation': None,
+                                     'work-type': 'JOURNAL_ARTICLE',
+                                     'publication-date': {
+                                      'month': {
+                                       'value': '01'
                                       },
-                                      "day": None,
-                                      "media-type": None,
-                                      "year": {
-                                       "value": "2016"
+                                      'day': None,
+                                      'media-type': None,
+                                      'year': {
+                                       'value': '2016'
                                       }
                                      },
-                                     "visibility": "PUBLIC",
-                                     "journal-title": None,
-                                     "work-external-identifiers": {
-                                      "scope": None,
-                                      "work-external-identifier": [
+                                     'visibility': 'PUBLIC',
+                                     'journal-title': None,
+                                     'work-external-identifiers': {
+                                      'scope': None,
+                                      'work-external-identifier': [
                                        {
-                                        "work-external-identifier-id": {
-                                         "value": "2016APh....72...11W"
+                                        'work-external-identifier-id': {
+                                         'value': '2016APh....72...11W'
                                         },
-                                        "work-external-identifier-type": "BIBCODE"
+                                        'work-external-identifier-type': 'BIBCODE'
                                        },
                                        {
-                                        "work-external-identifier-id": {
-                                         "value": "11002538"
+                                        'work-external-identifier-id': {
+                                         'value': '11002538'
                                         },
-                                        "work-external-identifier-type": "OTHER_ID"
+                                        'work-external-identifier-type': 'OTHER_ID'
                                        },
                                        {
-                                        "work-external-identifier-id": {
-                                         "value": "10.1016/j.astropartphys.2015.04.008"
+                                        'work-external-identifier-id': {
+                                         'value': '10.1016/j.astropartphys.2015.04.008'
                                         },
-                                        "work-external-identifier-type": "DOI"
+                                        'work-external-identifier-type': 'DOI'
                                        }
                                       ]
                                      },
-                                     "url": {
-                                      "value": "https://ui.adsabs.harvard.edu/#abs/2016APh....72...11W"
+                                     'url': {
+                                      'value': 'https://ui.adsabs.harvard.edu/#abs/2016APh....72...11W'
                                      },
-                                     "short-description": "We present studies for optimizing the next generation of"
-                                                          " ground-based imaging atmospheric Cherenkov telescopes "
-                                                          "(IACTs).",
-                                     "work-contributors": {
-                                      "contributor": [
+                                     'short-description': 'We present studies for optimizing the next generation of'
+                                                          ' ground-based imaging atmospheric Cherenkov telescopes '
+                                                          '(IACTs).',
+                                     'work-contributors': {
+                                      'contributor': [
                                        {
-                                        "contributor-orcid": None,
-                                        "contributor-attributes": {
-                                         "contributor-role": "AUTHOR",
-                                         "contributor-sequence": None
+                                        'contributor-orcid': None,
+                                        'contributor-attributes': {
+                                         'contributor-role': 'AUTHOR',
+                                         'contributor-sequence': None
                                         },
-                                        "credit-name": {
-                                         "visibility": "PUBLIC",
-                                         "value": "Wood, M."
+                                        'credit-name': {
+                                         'visibility': 'PUBLIC',
+                                         'value': 'Wood, M.'
                                         },
-                                        "contributor-email": None
+                                        'contributor-email': None
                                        },
                                        {
-                                        "contributor-orcid": None,
-                                        "contributor-attributes": {
-                                         "contributor-role": "AUTHOR",
-                                         "contributor-sequence": None
+                                        'contributor-orcid': None,
+                                        'contributor-attributes': {
+                                         'contributor-role': 'AUTHOR',
+                                         'contributor-sequence': None
                                         },
-                                        "credit-name": {
-                                         "visibility": "PUBLIC",
-                                         "value": "Jogler, T."
+                                        'credit-name': {
+                                         'visibility': 'PUBLIC',
+                                         'value': 'Jogler, T.'
                                         },
-                                        "contributor-email": None
+                                        'contributor-email': None
                                        },
                                        {
-                                        "contributor-orcid": None,
-                                        "contributor-attributes": {
-                                         "contributor-role": "AUTHOR",
-                                         "contributor-sequence": None
+                                        'contributor-orcid': None,
+                                        'contributor-attributes': {
+                                         'contributor-role': 'AUTHOR',
+                                         'contributor-sequence': None
                                         },
-                                        "credit-name": {
-                                         "visibility": "PUBLIC",
-                                         "value": "Dumm, J."
+                                        'credit-name': {
+                                         'visibility': 'PUBLIC',
+                                         'value': 'Dumm, J.'
                                         },
-                                        "contributor-email": None
+                                        'contributor-email': None
                                        },
                                        {
-                                        "contributor-orcid": None,
-                                        "contributor-attributes": {
-                                         "contributor-role": "AUTHOR",
-                                         "contributor-sequence": None
+                                        'contributor-orcid': None,
+                                        'contributor-attributes': {
+                                         'contributor-role': 'AUTHOR',
+                                         'contributor-sequence': None
                                         },
-                                        "credit-name": {
-                                         "visibility": "PUBLIC",
-                                         "value": "Funk, S."
+                                        'credit-name': {
+                                         'visibility': 'PUBLIC',
+                                         'value': 'Funk, S.'
                                         },
-                                        "contributor-email": None
+                                        'contributor-email': None
                                        }
                                       ]
                                      },
-                                     "work-source": None
+                                     'work-source': None
                                     }
                                    ]
                                 }
@@ -284,37 +306,50 @@ class TestOrcidService(TestBase):
                     }
 
         # replace all works
-        r = self.bumblebee_user.put('/orcid/{}/orcid-works'.format(orcid),
-                                    headers={'Orcid-Authorization': 'Bearer {}'.format(access_token)},
-                                    json=new_data)
+        r = self.bumblebee_user.put(
+            '/orcid/{}/orcid-works'.format(orcid),
+            headers={'Orcid-Authorization': 'Bearer {}'.format(access_token)},
+            json=new_data
+        )
+
         self.assertEqual(
             200,
             r.status_code,
-            msg='Expected a 200 response, but get: {}, {}'.format(r.status_code, r.json())
+            msg='Expected a 200 response, but get: {}, {}'
+                .format(r.status_code, r.json())
         )
 
         # over-write the one
-        r = self.bumblebee_user.post('/orcid/{}/orcid-works'.format(orcid),
-                                     headers={'Orcid-Authorization': 'Bearer {}'.format(access_token)},
-                                     json=new_data)
+        r = self.bumblebee_user.post(
+            '/orcid/{}/orcid-works'.format(orcid),
+            headers={'Orcid-Authorization': 'Bearer {}'.format(access_token)},
+            json=new_data
+        )
+
         self.assertEqual(
             201,
             r.status_code,
-            msg='Expected a 201 response, but get: {}, {}'.format(r.status_code, r.json())
+            msg='Expected a 201 response, but get: {}, {}'
+                .format(r.status_code, r.json())
         )
 
         # get it back
-        r = self.bumblebee_user.get('/orcid/{}/orcid-profile'.format(orcid),
-                                    headers={'Orcid-Authorization': 'Bearer {}'.format(access_token)})
+        r = self.bumblebee_user.get(
+            '/orcid/{}/orcid-profile'.format(orcid),
+            headers={'Orcid-Authorization': 'Bearer {}'.format(access_token)}
+        )
+
         self.assertEqual(
             200,
             r.status_code,
-            msg='Expected a 200 response, but get: {}, {}'.format(r.status_code, r.json())
+            msg='Expected a 200 response, but get: {}, {}'
+                .format(r.status_code, r.json())
         )
         self.assertIn(
             'orcid-profile',
             r.json(),
-            msg='Expected "orcid-profile" in the response, but it is not: {}, {}'.format(r.status_code, r.json())
+            msg='Expected "orcid-profile" in the response, '
+                'but it is not: {}, {}'.format(r.status_code, r.json())
         )
         self.assertEqual(
             1,
@@ -325,7 +360,8 @@ class TestOrcidService(TestBase):
 
     def test_crossx_headers(self):
         """
-        Test the cross-site origin (CORS) headers and they contain what we expect them to
+        Test the cross-site origin (CORS) headers and they contain what we
+        expect them to
         """
         for endpoint in [
             '/orcid/0000-0001-9886-2511/orcid-works',
@@ -336,5 +372,11 @@ class TestOrcidService(TestBase):
             self.assertIn('access-control-allow-origin', r.headers)
             self.assertIn('access-control-allow-headers', r.headers)
 
-            self.assertIn('ui.adsabs.harvard.edu', r.headers['access-control-allow-origin'])
-            self.assertIn('Orcid-Authorization', r.headers['access-control-allow-headers'])
+            self.assertIn(
+                'ui.adsabs.harvard.edu',
+                r.headers['access-control-allow-origin']
+            )
+            self.assertIn(
+                'Orcid-Authorization',
+                r.headers['access-control-allow-headers']
+            )

--- a/v1_0/api/recommender.py
+++ b/v1_0/api/recommender.py
@@ -1,5 +1,6 @@
+# encoding: utf-8
 """
-Integration tests for the Recommender service
+Functional tests for the Recommender service
 """
 
 from base import TestBase
@@ -14,35 +15,40 @@ class TestRecommender(TestBase):
         Generic setup. Updated to include a test bibcode.
         """
         super(TestRecommender, self).setUp()
-        self.test_bibcode = 'a'
+        self.test_bibcode = '2010MNRAS.409.1719J'
 
     def test_anonymous_user_existing_bibcode(self):
         """
-        Test an unauthenticated user has no access to the recommender for an existing bibcode
+        Test an unauthenticated user has no access to the recommender for an
+        existing bibcode
         """
         r = self.anonymous_user.get('/recommender/{}'.format(self.test_bibcode))
         self.assertEqual(
             r.status_code,
             401,
-            msg='Should get 401 when trying to get graphics for an existing bibcode, but get: {}, {}'
+            msg='Should get 401 when trying to get graphics for an '
+                'existing bibcode, but get: {}, {}'
                 .format(r.status_code, r.json())
         )
 
     def test_anonymous_user_non_existent_bibcode(self):
         """
-        Test an unauthenticated user has no access to the recommender even for a non-existent bibcode
+        Test an unauthenticated user has no access to the recommender even for a
+        non-existent bibcode
         """
         r = self.anonymous_user.get('/recommender/foo')
         self.assertEqual(
             r.status_code,
             401,
-            msg='Should get 401 when trying to get graphics for a non-existient bibcode, but get: {}, {}'
+            msg='Should get 401 when trying to get graphics for a '
+                'non-existient bibcode, but get: {}, {}'
                 .format(r.status_code, r.json())
         )
 
     def help_authenticated_user_get(self, user=None):
         """
-        Test that authenticated user can access the get end point for a given bibcode
+        Test that authenticated user can access the get end point for a given
+        bibcode
         :param user: the user to run the test on
         :type user: object
         """
@@ -50,7 +56,8 @@ class TestRecommender(TestBase):
         self.assertEqual(
             r.status_code,
             200,
-            msg='We should get 200 for an existing bibcode ({}), but get: {}, {}'
+            msg='We should get 200 for an existing bibcode "{}", '
+                'but get: {}, {}'
                 .format(self.test_bibcode, r.status_code, r.text)
         )
 
@@ -63,13 +70,15 @@ class TestRecommender(TestBase):
         self.assertEqual(
             data['paper'],
             self.test_bibcode,
-            msg='Response data structure should contain the bibcode, but does not: {}'.format(data)
+            msg='Response data structure should contain the bibcode, '
+                'but does not: {}'.format(data)
         )
 
         self.assertIn(
             'recommendations',
             data,
-            msg='Response data should have "recommendations" attribute, but does not: {}, {}'.format(data.keys(), data)
+            msg='Response data should have "recommendations" attribute, '
+                'but does not: {}, {}'.format(data.keys(), data)
         )
 
         self.assertIsInstance(
@@ -85,37 +94,43 @@ class TestRecommender(TestBase):
             self.assertIsInstance(
                 item,
                 dict,
-                msg='Items should be a dict but are type: {}, {}'.format(type(item), item)
+                msg='Items should be a dict but are type: {}, {}'
+                    .format(type(item), item)
             )
 
             actual_attr = item.keys()
             self.assertEqual(
                 actual_attr.sort(),
                 expected_attr.sort(),
-                msg='Expected {} != Actual {}'.format(expected_attr, actual_attr)
+                msg='Expected "{}" != Actual "{}"'
+                    .format(expected_attr, actual_attr)
             )
 
     def test_authenticated_user_get(self):
         """
-        Authenaticated users should be able to use the get end point, and the response should be as we expect
+        Authenaticated users should be able to use the get end point, and the
+        response should be as we expect
         """
         self.help_authenticated_user_get(user=self.authenticated_user)
         self.help_authenticated_user_get(user=self.bumblebee_user)
 
     def test_authenticated_user_non_existent_bibcode(self):
         """
-        Test that an authenticated user can use the get end point for a non-existent bibcode, but that the response
-        tells us the bibcode does not exist
+        Test that an authenticated user can use the get end point for a
+        non-existent bibcode, but that the response tells us the bibcode does
+        not exist
         """
         r = self.authenticated_user.get('/recommender/foobar')
         self.assertEqual(
             r.status_code,
             200,
-            msg='Non-existent bibcode should return 200, but returns: {}, {}'.format(r.status_code, r.text)
+            msg='Non-existent bibcode should return 200, but returns: {}, {}'
+                .format(r.status_code, r.text)
         )
         self.assertIn(
             'Error',
             r.json(),
-            msg='Non-existent bibcode should return an Error attribute, but does not: {} [status: {}]'
+            msg='Non-existent bibcode should return an Error attribute, '
+                'but does not: {} [status: {}]'
                 .format(r.json(), r.status_code)
         )

--- a/v1_0/api/solr.py
+++ b/v1_0/api/solr.py
@@ -1,7 +1,9 @@
+# encoding: utf-8
 """
-Integration tests for the Recommender service
+Functional tests for the solr-service
 
-'solr-service' is synonymous with 'search' when looking at the end points on the API
+'solr-service' is synonymous with 'search' when looking at the end points on the
+ API
 """
 
 import time
@@ -17,11 +19,16 @@ class TestSolr(TestBase):
         Check the response contains Headers and the limits are there
         """
 
-        r = self.authenticated_user.get('/search/query', params={'q': 'title:"{}"'.format(time.time())})
+        r = self.authenticated_user.get(
+            '/search/query',
+            params={'q': 'title:"{}"'.format(time.time())}
+        )
         self.assertEqual('5000', r.headers['x-ratelimit-limit'])
 
         old_limit = int(r.headers['x-ratelimit-remaining'])
-        r = self.authenticated_user.get('/search/query', params={'q': 'title:"{}"'.format(time.time())})
-
+        r = self.authenticated_user.get(
+            '/search/query',
+            params={'q': 'title:"{}"'.format(time.time())}
+        )
         self.assertEqual(str(old_limit-1), r.headers['x-ratelimit-remaining'])
         self.assertIn('x-ratelimit-reset', r.headers)

--- a/v1_0/api/vis.py
+++ b/v1_0/api/vis.py
@@ -1,5 +1,6 @@
+# encoding: utf-8
 """
-Integration tests for the visualisation services service
+Functional tests for the visualisation services service
 """
 
 import json
@@ -8,20 +9,24 @@ from base import TestBase
 
 class TestPaperNetwork(TestBase):
     """
-    Base class for testing the paper-network end point of the visualisation services
+    Base class for testing the paper-network end point of the visualisation
+    services
     """
     def setUp(self):
         """
         Generic setup. Updated to include a test bibcode.
         """
         super(TestPaperNetwork, self).setUp()
-        self.test_params = dict(query=['{"q": "author:\\"Elliott, J.\\""}'])
+        self.test_params = dict(query=['{"q": "author:\\"Accomazzi, A\\""}'])
 
     def test_get_request_unauthorized_user(self):
         """
         Show that you cannot get a paper-network for an unauthorized user
         """
-        r = self.anonymous_user.post('/vis/paper-network', params=self.test_params)
+        r = self.anonymous_user.post(
+            '/vis/paper-network',
+            params=self.test_params
+        )
         self.assertEqual(
             r.status_code,
             401,
@@ -31,11 +36,16 @@ class TestPaperNetwork(TestBase):
 
     def helper_check_paper_network(self, user=None):
         """
-        Tests the get end point of the paper-network for the visualisation services for an authorized user.
+        Tests the get end point of the paper-network for the visualisation
+        services for an authorized user.
         :param user: the user to run the test on
         :type user: object
         """
-        r = user.post('/vis/paper-network', data=json.dumps(self.test_params), headers={'Content-Type': 'application/json'})
+        r = user.post(
+            '/vis/paper-network',
+            data=json.dumps(self.test_params),
+            headers={'Content-Type': 'application/json'}
+        )
 
         self.assertEqual(
             r.status_code,
@@ -57,7 +67,8 @@ class TestPaperNetwork(TestBase):
         self.assertEqual(
             expected_attr.sort(),
             actual_attr.sort(),
-            msg='Response should contain keywords: {} but does not: {}'.format(expected_attr, actual_attr)
+            msg='Response should contain keywords: {} but does not: {}'
+                .format(expected_attr, actual_attr)
         )
 
         expected_attr = ['summaryGraph', 'fullGraph']
@@ -65,49 +76,60 @@ class TestPaperNetwork(TestBase):
         self.assertEqual(
             expected_attr.sort(),
             actual_attr.sort(),
-            msg='Data keywould should contain {}, but does not: {}'.format(expected_attr, actual_attr)
+            msg='Data keywould should contain {}, but does not: {}'
+                .format(expected_attr, actual_attr)
         )
 
-        expected_attr = [u'directed', u'graph', u'nodes', u'links', u'multigraph']
+        expected_attr = [
+            u'directed', u'graph', u'nodes', u'links', u'multigraph'
+        ]
         actual_attr = pdata['data']['summaryGraph'].keys()
         self.assertEqual(
             expected_attr,
             actual_attr,
-            msg='Both graphs should have the same attributes {}, but do not: {}'.format(expected_attr, actual_attr)
+            msg='Both graphs should have the same attributes {}, but do not: {}'
+                .format(expected_attr, actual_attr)
         )
         actual_attr = pdata['data']['fullGraph'].keys()
         self.assertEqual(
             expected_attr,
             actual_attr,
-            msg='Both graphs should have the same attributes {}, but do not: {}'.format(expected_attr, actual_attr)
+            msg='Both graphs should have the same attributes {}, but do not: {}'
+                .format(expected_attr, actual_attr)
         )
 
         graph = pdata['data']['summaryGraph']
         self.assertIsInstance(
             graph['nodes'],
             list,
-            msg='Nodes should be type list, but is type: {}, {}'.format(type(graph['nodes']), graph['nodes'])
+            msg='Nodes should be type list, but is type: {}, {}'
+                .format(type(graph['nodes']), graph['nodes'])
         )
 
-        expected_attr = [u'paper_count', u'node_label', u'total_citations', u'node_name',
-                         u'top_common_references', u'total_reads', u'stable_index', u'id']
+        expected_attr = [
+            u'paper_count', u'node_label', u'total_citations', u'node_name',
+            u'top_common_references', u'total_reads', u'stable_index', u'id'
+        ]
         for item in graph['nodes']:
             self.assertIsInstance(
                 item,
                 dict,
-                msg='Content of nodes list should be dict, but is: {}, {}'.format(type(item), item)
+                msg='Content of nodes list should be dict, but is: {}, {}'
+                    .format(type(item), item)
             )
             actual_attr = item.keys()
             self.assertEqual(
                 expected_attr.sort(),
                 actual_attr.sort(),
-                msg='We expect the following attributes {} but do not get them: {}'.format(expected_attr, actual_attr)
+                msg='We expect the following attributes {}, but do not get '
+                    'them: {}'.format(expected_attr, actual_attr)
             )
 
         self.assertIsInstance(
             graph['links'],
             list,
-            msg='Links should be type list, but is type: {}, {}'.format(type(graph['links']), graph['links'])
+            msg='Links should be type list, but is type: {}, {}'
+                .format(type(graph['links']), graph['links'])
         )
 
         expected_attr = [u'source', u'target', u'weight']
@@ -115,20 +137,23 @@ class TestPaperNetwork(TestBase):
             self.assertIsInstance(
                 item,
                 dict,
-                msg='Content of links should be a dict, but is: {}, {}'.format(type(item), item)
+                msg='Content of links should be a dict, but is: {}, {}'
+                    .format(type(item), item)
             )
             actual_attr = item.keys()
             self.assertEqual(
                 expected_attr.sort(),
                 actual_attr.sort(),
-                msg='We expect the following attributes {} but do not get them {}'.format(expected_attr, actual_attr)
+                msg='We expect the following attributes {}, but do not get '
+                    'them {}'.format(expected_attr, actual_attr)
             )
 
         graph = pdata['data']['fullGraph']
         self.assertIsInstance(
             graph['nodes'],
             list,
-            msg='Nodes should be type list, but is type: {}, {}'.format(type(graph['nodes']), graph['nodes'])
+            msg='Nodes should be type list, but is type: {}, {}'
+                .format(type(graph['nodes']), graph['nodes'])
         )
 
         expected_attr = [u'read_count', u'group', u'title', u'first_author',
@@ -137,19 +162,22 @@ class TestPaperNetwork(TestBase):
             self.assertIsInstance(
                 item,
                 dict,
-                msg='Content of nodes list should be dict, but is: {}, {}'.format(type(item), item)
+                msg='Content of nodes list should be dict, but is: {}, {}'
+                    .format(type(item), item)
             )
             actual_attr = item.keys()
             self.assertItemsEqual(
                 expected_attr,
                 actual_attr,
-                msg='We expect the following attributes {} but do not get them {}'.format(expected_attr, actual_attr)
+                msg='We expect the following attributes {}, but do not get '
+                    'them {}'.format(expected_attr, actual_attr)
             )
 
         self.assertIsInstance(
             graph['links'],
             list,
-            msg='Links should be type list, but is type: {}, {}'.format(type(graph['links']), graph['links'])
+            msg='Links should be type list, but is type: {}, {}'
+                .format(type(graph['links']), graph['links'])
         )
 
         expected_attr = [u'source', u'weight', u'overlap', u'target']
@@ -157,18 +185,21 @@ class TestPaperNetwork(TestBase):
             self.assertIsInstance(
                 item,
                 dict,
-                msg='Content of links list should be dict, but is: {}, {}'.format(type(item), item)
+                msg='Content of links list should be dict, but is: {}, {}'
+                    .format(type(item), item)
             )
             actual_attr = item.keys()
             self.assertItemsEqual(
                 expected_attr,
                 actual_attr,
-                msg='We expect the following attributes {} but do not get them {}'.format(expected_attr, actual_attr)
+                msg='We expect the following attributes {}, but do not get '
+                    'them {}'.format(expected_attr, actual_attr)
             )
 
     def test_get_request_authorized_user(self):
         """
-        Tests the get end point of the paper-network for the visualisation services for a set of authorized users.
+        Tests the get end point of the paper-network for the visualisation
+        services for a set of authorized users.
         """
         self.helper_check_paper_network(user=self.authenticated_user)
         self.helper_check_paper_network(user=self.bumblebee_user)
@@ -176,38 +207,49 @@ class TestPaperNetwork(TestBase):
 
 class TestAuthorNetwork(TestBase):
     """
-    Base class for testing the paper-network end point of the visualisation services
+    Base class for testing the paper-network end point of the visualisation
+    services
     """
     def setUp(self):
         """
         Generic setup. Updated to include a test bibcode.
         """
         super(TestAuthorNetwork, self).setUp()
-        self.test_params = dict(query=['{"q": "author:\\"Elliott, J.\\""}'])
+        self.test_params = dict(query=['{"q": "author:\\"Accomazzi, A\\""}'])
 
     def test_get_request_unauthorized_user(self):
         """
         Show that you cannot get an author-network for an unauthorized user
         """
-        r = self.anonymous_user.post('/vis/author-network', params=self.test_params)
+        r = self.anonymous_user.post(
+            '/vis/author-network',
+            params=self.test_params
+        )
         self.assertEqual(
             r.status_code,
             401,
-            msg='We should get a 401 for an unauthorized user, but get: {}, {}'.format(r.status_code, r.json())
+            msg='We should get a 401 for an unauthorized user, but get: {}, {}'
+                .format(r.status_code, r.json())
         )
 
     def helper_check_author_network(self, user=None):
         """
-        Tests the get end point of the author-network for the visualisation services for an authorized user.
+        Tests the get end point of the author-network for the visualisation
+        services for an authorized user.
         :param user: the user to run the test on
         :type user: object
         """
-        r = user.post('/vis/author-network', data=json.dumps(self.test_params), headers={'Content-Type': 'application/json'})
+        r = user.post(
+            '/vis/author-network',
+            data=json.dumps(self.test_params),
+            headers={'Content-Type': 'application/json'}
+        )
 
         self.assertEqual(
             r.status_code,
             200,
-            msg='Response should be a 200 for get request of authorized user, but get: {}, {}'
+            msg='Response should be a 200 for get request of authorized user, '
+                'but get: {}, {}'
                 .format(r.status_code, r.json())
         )
 
@@ -215,7 +257,8 @@ class TestAuthorNetwork(TestBase):
         self.assertIsInstance(
             data,
             dict,
-            msg='Response should be type dict, but is type: {}, {}'.format(type(data), data)
+            msg='Response should be type dict, but is type: {}, {}'
+                .format(type(data), data)
         )
 
         expected_keys = ['msg', 'data']
@@ -223,7 +266,8 @@ class TestAuthorNetwork(TestBase):
         self.assertEqual(
             expected_keys.sort(),
             actual_keys.sort(),
-            msg='We expect the following keys in data: {}, but have: {}'.format(expected_keys, actual_keys)
+            msg='We expect the following keys in data: {}, but have: {}'
+                .format(expected_keys, actual_keys)
         )
 
         expected_attr = [u'bibcode_dict', u'root', u'link_data']
@@ -231,7 +275,8 @@ class TestAuthorNetwork(TestBase):
         self.assertEqual(
             expected_attr.sort(),
             actual_attr.sort(),
-            msg='We expect the following attributes {} but have: {}'.format(expected_attr, actual_attr)
+            msg='We expect the following attributes {} but have: {}'
+                .format(expected_attr, actual_attr)
         )
 
         expected_attr = ['read_count', 'title', 'citation_count', 'authors']
@@ -239,19 +284,22 @@ class TestAuthorNetwork(TestBase):
             self.assertEqual(
                 len(bibcode),
                 19,
-                msg='Bibcodes should have 19 characters, but it has: {} [bibcode]'.format(len(bibcode), bibcode)
+                msg='Bibcodes should have 19 characters, '
+                    'but it has: {} [bibcode]'.format(len(bibcode), bibcode)
             )
             self.assertIsInstance(
                 bibinfo,
                 dict,
-                msg='Bibcode information should be type dict, but is type: {}, {}'.format(type(bibinfo), bibinfo)
+                msg='Bibcode information should be type dict, '
+                    'but is type: {}, {}'.format(type(bibinfo), bibinfo)
             )
 
             actual_attr = bibinfo.keys()
             self.assertEqual(
                 expected_attr.sort(),
                 actual_attr.sort(),
-                msg='BibInfo should have attributes {}, but has: {}'.format(expected_attr, actual_attr)
+                msg='BibInfo should have attributes {}, but has: {}'
+                    .format(expected_attr, actual_attr)
             )
 
         expected_attr = ['name', 'children']
@@ -259,43 +307,50 @@ class TestAuthorNetwork(TestBase):
         self.assertEqual(
             expected_attr.sort(),
             actual_attr.sort(),
-            msg='Root entry should have attributes {}, but has: {}'.format(expected_attr, actual_attr)
+            msg='Root entry should have attributes {}, but has: {}'
+                .format(expected_attr, actual_attr)
         )
 
         children = data['data']['root']['children']
         self.assertIsInstance(
             children,
             list,
-            msg='Children of root should be type list, but is type: {}, {}'.format(type(children), children)
+            msg='Children of root should be type list, but is type: {}, {}'
+                .format(type(children), children)
         )
         expected_attr = ['name', 'children']
         actual_attr = children[0].keys()
         self.assertEqual(
             expected_attr.sort(),
             actual_attr.sort(),
-            msg='First entry should have attributes {}, but has {}'.format(expected_attr, actual_attr)
+            msg='First entry should have attributes {}, but has {}'
+                .format(expected_attr, actual_attr)
         )
 
         link_data = data['data']['link_data']
         self.assertIsInstance(
             link_data,
             list,
-            msg='link_data should be type list, but is type: {}, {}'.format(type(link_data), link_data)
+            msg='link_data should be type list, but is type: {}, {}'
+                .format(type(link_data), link_data)
         )
         for item in link_data:
             self.assertIsInstance(
                 item,
                 list,
-                msg='Each item of link_data should be a list, but this is type: {}, {}'.format(type(item), item)
+                msg='Each item of link_data should be a list, '
+                    'but this is type: {}, {}'.format(type(item), item)
             )
             self.assertTrue(
                 all(isinstance(int(x), int) for x in item),
-                msg='Each item of link_data should contain a list of numbers, but does not: {}'.format(item)
+                msg='Each item of link_data should contain a list of numbers, '
+                    'but does not: {}'.format(item)
             )
 
     def test_get_request_authorized_user(self):
         """
-        Tests the get end point of the paper-network for the visualisation services for a set of authorized users.
+        Tests the get end point of the paper-network for the visualisation
+        services for a set of authorized users.
         """
         self.helper_check_author_network(user=self.authenticated_user)
         self.helper_check_author_network(user=self.bumblebee_user)
@@ -303,20 +358,28 @@ class TestAuthorNetwork(TestBase):
 
 class TestWordCloud(TestBase):
     """
-    Base class for testing the word-cloud end point of the visualisation services
+    Base class for testing the word-cloud end point of the visualisation
+    services
     """
     def setUp(self):
         """
         Generic setup. Updated to include a test bibcode.
         """
         super(TestWordCloud, self).setUp()
-        self.test_params = dict(query=['{"q": "author:\\"Elliott, J.\\""}'])
+        self.test_params = dict(
+            query=['{"q": "author:\\"Accomazzi, A\\" year:1991-1993"}']
+        )
 
     def test_get_request_unauthorized_user(self):
         """
         Show that you cannot get a word-cloud for an unauthorized user
         """
-        r = self.anonymous_user.post('/vis/author-network', data=json.dumps(self.test_params), headers={'Content-Type': 'application/json'})
+        r = self.anonymous_user.post(
+            '/vis/word-cloud',
+            data=json.dumps(self.test_params),
+            headers={'Content-Type': 'application/json'}
+        )
+
         self.assertEqual(
             r.status_code,
             401,
@@ -326,24 +389,31 @@ class TestWordCloud(TestBase):
 
     def helper_check_word_cloud(self, user=None):
         """
-        Tests the get end point of the word-cloud for the visualisation services for an authorized user.
+        Tests the get end point of the word-cloud for the visualisation services
+         for an authorized user.
         :param user: the user to run the test on
         :type user: object
         """
-        r = user.post('/vis/word-cloud', data=json.dumps(self.test_params), headers={'Content-Type': 'application/json'})
+        r = user.post(
+            '/vis/word-cloud',
+            data=json.dumps(self.test_params),
+            headers={'Content-Type': 'application/json'}
+        )
 
         # We should get a 200 back
         self.assertEqual(
             r.status_code,
             200,
-            msg='We should get 200 response but get: {}, {}'.format(r.status_code, r.json())
+            msg='We should get 200 response but get: {}, {}'
+                .format(r.status_code, r.json())
         )
 
         data = r.json()
         self.assertIsInstance(
             data,
             dict,
-            msg='Response should be dict type, but is: {}, {}'.format(type(data), data)
+            msg='Response should be dict type, but is: {}, {}'
+                .format(type(data), data)
         )
 
         expected_attr = ['idf', 'record_count', 'total_occurrences']
@@ -351,19 +421,22 @@ class TestWordCloud(TestBase):
             self.assertIsInstance(
                 entry,
                 dict,
-                msg='Each value of data should be dict, but is: {}, {}'.format(type(entry), entry)
+                msg='Each value of data should be dict, but is: {}, {}'
+                    .format(type(entry), entry)
             )
 
             actual_attr = entry.keys()
             self.assertEqual(
                 expected_attr.sort(),
                 actual_attr.sort(),
-                msg='Expected entry to have attributes {}, but has {}'.format(expected_attr, actual_attr)
+                msg='Expected entry to have attributes {}, but has {}'
+                    .format(expected_attr, actual_attr)
             )
 
     def test_get_request_authorized_user(self):
         """
-        Tests the get end point of the word-cloud for the visualisation services for a set of authorized users.
+        Tests the get end point of the word-cloud for the visualisation services
+        for a set of authorized users.
         """
         self.helper_check_word_cloud(user=self.authenticated_user)
         self.helper_check_word_cloud(user=self.bumblebee_user)


### PR DESCRIPTION
Some of the functional tests would try to add data to the backend
databases, and do not do any cleaning up. There is also nothing
specifically set up for these types of tests currently, and so for
now they have been given the *skip* decorator. Most specifically,
the services:

  * myads (tries to store data for a user)
  * orcid (the entire workflow requires data)

Some PEP8 was also done out of OCD.